### PR TITLE
Fixes #18 - IE9 throws "SCRIPT1014: Invalid character"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -349,7 +349,7 @@ class ReactSpeedometer extends React.Component {
                 // ref: https://stackoverflow.com/a/29771751/1410291
                 function assemble(literal, params) {
                     // ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
-                    return new Function(params, "return `"+literal+"`;");
+                    return new Function(params, "return '"+literal+"';");
                 }
                 var template = assemble(config.currentValueText, "value");
                 return template(value);


### PR DESCRIPTION
Fixes #18 - IE9 throws "SCRIPT1014: Invalid character", even when page charset set is UTF-8