### PR TITLE
Added "types" export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "module": "./dist/react-d3-speedometer.es.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/react-d3-speedometer.es.js",
       "require": "./dist/react-d3-speedometer.umd.js"
     },


### PR DESCRIPTION
The current `package.json` results in an error in TypeScript 5.2.2 (perhaps also for versions back to 4.7). Here's the error:

```java
error TS7016: Could not find a declaration file for module 'react-d3-speedometer'. '<path-to-project>/node_modules/react-d3-speedometer/dist/react-d3-speedometer.es.js' implicitly has an 'any' type.
  There are types at '<path-to-project>/node_modules/react-d3-speedometer/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'react-d3-speedometer' library may need to update its package.json or typing.
```

According to [this StackOverflow post](https://stackoverflow.com/a/76212193/1426327), when `"exports"` is defined `"types"` needs to be defined in the `"exports"`. 

Adding `"types": "./dist/index.d.ts"` to `"exports"` fixes things, at least it does for my project.