### PR TITLE
build: externalize react/jsx-runtime and react-dom/client

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -38,7 +38,7 @@ module.exports = defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['react', 'react-dom', 'window'],
+      external: ['react', 'react/jsx-runtime', 'react-dom', 'react-dom/client', 'window'],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps


### PR DESCRIPTION
Optimizes bundeling sizes, because at the moment react/jsx-runtime is being bundled unnecessary leading to a overhead in production, by externalizing react/jsx-runtime and also for the future react-dom/client

Would be awesome for having a quick merge, because no breaking change, no problem, just removes overhead, reduce bundle size, and also provides a fix.

Also
- Fixes #189 