### PR TITLE
Allow simultaneous display of segment and stop labels

### DIFF
--- a/src/core/config/index.js
+++ b/src/core/config/index.js
@@ -32,6 +32,8 @@ export const DEFAULT_PROPS = {
 
   // custom segment labels
   customSegmentLabels: [],
+  // show custom segment labels and stops
+  showStopsAndCustomSegmentLabels: false,
 
   // color strings
   needleColor: 'steelblue',
@@ -116,6 +118,8 @@ export const getConfig = ({ PROPS, parentWidth, parentHeight }) => {
 
     // custom segment labels
     customSegmentLabels: PROPS.customSegmentLabels,
+    // show custom segment labels and stops
+    showStopsAndCustomSegmentLabels: PROPS.showStopsAndCustomSegmentLabels,
 
     // max segment labels
     maxSegmentLabels: calculateSegmentLabelCount({

--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -141,7 +141,9 @@ export function _renderLabels({ config, svg, centerTx, r }) {
       range,
     })
     // do not proceed
-    return
+    if (!config.showStopsAndCustomSegmentLabels) {
+      return
+    }
   }
 
   // normal label rendering

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -81,6 +81,7 @@ declare module 'react-d3-speedometer' {
     customSegmentStops?: number[]
 
     customSegmentLabels?: CustomSegmentLabel[]
+    showStopsAndCustomSegmentLabels?: boolean
 
     labelFontSize?: string
     valueTextFontSize?: string


### PR DESCRIPTION
Exposes a new Prop to `ReactSpeedometer` called `showStopsAndCustomSegmentLabels`. This Prop is not required and defaults to `false` to maintain existing behavior for users on earlier versions.

The logic simply allows the `_renderLabels` function to continue if this Prop is set to `true`. Previously, if `isCustomLabelsPresent && isCustomLabelsValid` evaluated to `true` the function would strictly render the custom segment labels and then exit, skipping the logic to render the segment stop labels.